### PR TITLE
Fix bug with path separators in Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,16 @@ else(NOT GIT_EXECUTABLE)
     set(CACTUS_VERSION "no-git")
 endif()
 
+# get appropriate path separator
+if("${CMAKE_HOST_SYSTEM}" MATCHES ".*Windows.*")
+  set(SEP "\\;")
+else() # e.g. Linux
+  set(SEP "/")
+endif()
+
+# add definitions
 add_definitions(-DVERSION="${CACTUS_VERSION}")
+add_definitions(-DPATHSEP="${SEP}")
 
 # create source lists
 file(GLOB_RECURSE mod_sources ${PROJECT_SOURCE_DIR}/mod/**.f95)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,8 @@ else(NOT GIT_EXECUTABLE)
 endif()
 
 # get appropriate path separator
-if("${CMAKE_HOST_SYSTEM}" MATCHES ".*Windows.*")
-  set(SEP "\\;")
+if(MINGW OR WIN32 OR MSYS)
+  set(SEP "\\")
 else() # e.g. Linux
   set(SEP "/")
 endif()
@@ -75,7 +75,7 @@ file(GLOB_RECURSE prog_sources ${PROJECT_SOURCE_DIR}/src/*.f95)
 
 add_executable(cactus ${prog_sources} ${mod_sources})
 target_compile_options(cactus PUBLIC ${LAPACK_LINKER_FLAGS})
-if(MINGW)
+if(MINGW OR WIN32 OR MSYS)
     target_link_libraries(cactus ${LAPACK_LIBRARIES} -static)
 else()
     target_link_libraries(cactus ${LAPACK_LIBRARIES})

--- a/src/CACTUS.f95
+++ b/src/CACTUS.f95
@@ -98,7 +98,9 @@ program CACTUS
     call print_compiler_info()
     write(*,*) ''
 
-
+    call get_path_separator()
+    write(*,*) 'PATH SEPARATOR IS: '//path_separator
+    
     ! Alert the user if OpenMP is enabled.
 !$  write(*,*) 'OpenMP is Enabled.'
 

--- a/src/mod/pathseparator.f95
+++ b/src/mod/pathseparator.f95
@@ -7,13 +7,13 @@ module pathseparator
 contains
     
     subroutine get_path_separator()
-        ! get_path_separator() : Get the path delimiter ('/' for Linux, '\' for Windows)
-        character(len=99999) :: path
 
-        call get_environment_variable('PATH',path)
-
-        path_separator = path(1:1)
-
+#if defined(PATHSEP)
+        path_separator = PATHSEP
+#else
+        ! fallback
+        path_separator = '/'  
+#endif
     end subroutine get_path_separator
 
 end module pathseparator


### PR DESCRIPTION
@kmruehl found some issues with file output on Windows. The root cause was improper file separators on Windows machines. Apparently the call to `system('mkdir [...]')` on Windows requires the `\` file separator be used.

Here, CMake is used to supply the appropriate path separator. This seemed easier than messing around with all kinds of compiler preproc directives. It's also cleaner than parsing the `PATH` env var, which was the old solution and clearly didn't work for native Windows execution.

@kmruehl this is an alternative to https://github.com/SNL-WaterPower/CACTUS/pull/21

