### PR TITLE
Update compile.md instructions - `make install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
   - mkdir -p build
   - cd build
   - cmake -DOPENMP=OFF ../ 
-  - make install
+  - make
   - cd ..
   - bin/cactus
   - cd test/RegTest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ else()
     target_link_libraries(cactus ${LAPACK_LIBRARIES})
 endif()
 
-# install
-install(TARGETS cactus
-        RUNTIME DESTINATION ${PROJECT_SOURCE_DIR}/bin/
-        )
+# build to ./bin
+set_target_properties(cactus
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/bin/")

--- a/doc/compile.md
+++ b/doc/compile.md
@@ -10,7 +10,7 @@ Compilation requires CMake, which can be installed by your OS package manager, o
    mkdir -p build
    cd build
    cmake ../ 
-   make install
+   make
    ```
    This will produce a `cactus` executable in the `bin/` folder.  
    Support for OpenMP may be disabled by adding the `DOPENMP=OFF` flag to the `cmake` call, as below.

--- a/doc/compile.md
+++ b/doc/compile.md
@@ -10,8 +10,9 @@ Compilation requires CMake, which can be installed by your OS package manager, o
    mkdir -p build
    cd build
    cmake ../ 
-   make
-	```
+   make install
+   ```
+   This will produce a `cactus` executable in the `bin/` folder.  
    Support for OpenMP may be disabled by adding the `DOPENMP=OFF` flag to the `cmake` call, as below.
    ```
    cmake -DOPENMP=OFF ../ 


### PR DESCRIPTION
`make install` is required in order to get the `cactus` file to be moved to the `bin/` folder.