### PR TITLE
Fix path issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ CM/
 Thumbs.db
 ~*.docx
 test/RegTest/__pycache__
+build/

--- a/src/CACTUS.f95
+++ b/src/CACTUS.f95
@@ -184,26 +184,26 @@ program CACTUS
 
     ! Create output directories
     ! Create the main output directory
-    call system('mkdir '//adjustl(trim(OutputPath)))
+    call system('mkdir "'//adjustl(trim(OutputPath))//path_separator//'"')
 
     ! Field data
     if (FieldOutFlag > 0) then
-        call system('mkdir '//FieldOutputPath)
+        call system('mkdir "'//FieldOutputPath//path_separator//'"')
     end if
 
     ! Wake element data
     if (WakeElemOutFlag > 0) then
-        call system('mkdir '//adjustl(trim(WakeElemOutputPath)))
+        call system('mkdir "'//adjustl(trim(WakeElemOutputPath))//path_separator//'"')
     end if
 
     ! Wall data
     if (WallOutFlag > 0) then
-        call system('mkdir '//adjustl(trim(WallOutputPath)))
+        call system('mkdir "'//adjustl(trim(WallOutputPath))//path_separator//'"')
     end if
 
     ! Probe data
     if (ProbeFlag > 0) then
-        call system('mkdir '//adjustl(trim(ProbeOutputPath)))
+        call system('mkdir "'//adjustl(trim(ProbeOutputPath))//path_separator//'"')
     end if
 
     ! Open output files

--- a/src/CACTUS.f95
+++ b/src/CACTUS.f95
@@ -188,7 +188,7 @@ program CACTUS
 
     ! Field data
     if (FieldOutFlag > 0) then
-        call system('mkdir "'//FieldOutputPath//path_separator//'"')
+        call system('mkdir "'//adjustl(trim(FieldOutputPath))//path_separator//'"')
     end if
 
     ! Wake element data


### PR DESCRIPTION
Double-quote paths and add a trailing path separator. Fixes issues when paths have spaces, and might fix "bad syntax" errors for `mkdir` on Windows (see #24).

@danrhouck can you build this branch and see if it fixes your issue? I don't have access to a Windows machine right now.